### PR TITLE
Fix periodic popout flicker from background device polling

### DIFF
--- a/USBManagerService.qml
+++ b/USBManagerService.qml
@@ -16,6 +16,9 @@ Singleton {
 
     property var devices: []
     property bool isLoading: false
+    // Tracks whether the first list has ever completed, so periodic background
+    // polls don't flash the "Loading…" placeholder while the popout is open.
+    property bool _hasLoadedOnce: false
     signal devicesUpdated()
 
     // Resolved at startup: DMS installs to ~/.config/DankMaterialShell/plugins/<id> (usbManager).
@@ -26,9 +29,13 @@ Singleton {
     function refreshDevices() {
         if (!_pluginDirReady || !pluginDir)
             return;
-        isLoading = true;
+        // Only show the spinner on the genuine first load. Background polls
+        // (every 5s) must not toggle isLoading, or the list flickers each tick.
+        if (!_hasLoadedOnce)
+            isLoading = true;
         Proc.runCommand("usbManager:list", ["bash", pluginDir + "/helpers/usb_manager.sh", "list"], (output, exitCode) => {
             isLoading = false;
+            _hasLoadedOnce = true;
             if (exitCode !== 0) {
                 console.error("USBManager: list failed:", output);
                 ToastService.showError("USB Manager", "Failed to list USB devices.");
@@ -36,6 +43,11 @@ Singleton {
             }
             try {
                 const arr = JSON.parse(output || "[]");
+                // Skip the reassignment when nothing changed: a fresh array from
+                // JSON.parse resets the ListView model and rebuilds every delegate,
+                // which is the visible flicker on each periodic refresh.
+                if (JSON.stringify(arr) === JSON.stringify(root.devices))
+                    return;
                 root.devices = arr;
                 root.devicesUpdated();
             } catch (e) {


### PR DESCRIPTION
## Problem

When the bar popout is open, it flickers on a regular ~5s cadence — the
device list briefly disappears and reappears (looks like the menu closing
and reopening).

## Cause

The repeating 5s `Timer` in `USBManager.qml` calls
`USBManagerService.refreshDevices()` on every tick, even while the popout
is open. Each refresh does two disruptive things:

1. Sets `isLoading = true` then `false`. The list's `visible` binding
   depends on `!isLoading`, so the `ListView` is hidden and the
   "Loading…" placeholder flashes every tick.
2. Reassigns `devices` to a brand-new array from `JSON.parse(...)`. Even
   when the data is identical, a new array resets the `ListView` model and
   tears down/rebuilds every delegate — a visible repaint.

Both fire every 5s → the periodic flicker. (The `udisksctl monitor`
already handles hotplug events, so the poll is belt-and-suspenders.)

## Fix

Make background refreshes non-disruptive in `refreshDevices()`:

- Only show the loading spinner on the genuine first load, tracked with a
  new `_hasLoadedOnce` flag. Periodic polls no longer toggle `isLoading`.
- Skip the `devices` reassignment and `devicesUpdated()` signal when the
  freshly parsed list is identical to the current one (compared via
  `JSON.stringify`). No identical-array churn → no model reset.

The mount flow is unaffected: a successful mount changes the `mountpoint`,
so the list differs and `devicesUpdated()` still fires as before.

## Testing

Reproduced the flicker, applied the fix, and confirmed the popout stays
stable for 15–20s with and without a USB drive connected. `qmllint` reports
no syntax errors (only the expected unresolved `qs.*` import warnings).